### PR TITLE
Erro de compilação na ObjectsMappers.pas Delphi 12 para Android.

### DIFF
--- a/src/ObjectsMappers.pas
+++ b/src/ObjectsMappers.pas
@@ -1181,7 +1181,7 @@ begin
           if _property.PropertyType.QualifiedName = 'System.SysUtils.TTimeStamp' then
           begin
             ts := _property.GetValue(AObject).AsType<System.SysUtils.TTimeStamp>;
-            JSONObject.AddPair(f, TJSONNumber.Create(TimeStampToMsecs(ts)));
+            JSONObject.AddPair(f, TJSONNumber.Create(Double(TimeStampToMsecs(ts))));
           end;
         end;
       tkClass:


### PR DESCRIPTION
Identifiquei um erro na linha 1184 quando compilando para Android em Delphi 12. Dá um erro de ambiguidade e não deixa compilar. Testei a alteração da linha no Delhi 11.3 e 12 pra ver se precisaria de alguma diretiva de compilação e ambos os Delphis não houve problemas com a alteração, sugiro avaliar e modificar se necessário.

Antes
JSONObject.AddPair(f, TJSONNumber.Create(TimeStampToMsecs(ts)));

Depois
JSONObject.AddPair(f, TJSONNumber.Create(Double(TimeStampToMsecs(ts))));